### PR TITLE
dockercompose/fix-mysql-encoding

### DIFF
--- a/DummyData/customconfig.cnf
+++ b/DummyData/customconfig.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+character-set-server = utf8
+collation-server = utf8_unicode_ci
+skip-character-set-client-handshake

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,10 @@ services:
   database:
     image: "mysql:8"
     container_name: mysql
-    command: "--default-authentication-plugin=mysql_native_password"
+    command: '--default-authentication-plugin=mysql_native_password'
     restart: always
     volumes:
+      - ./DummyData/customconfig.cnf:/etc/mysql/conf.d/custom.cnf
       - ./DummyData/sqlfiles:/docker-entrypoint-initdb.d
     environment:
       - "MYSQL_ROOT_PASSWORD=secret"


### PR DESCRIPTION
sets encoding of db initilization to UTF8